### PR TITLE
fix: remove duplicate search event listeners

### DIFF
--- a/index.html
+++ b/index.html
@@ -770,8 +770,7 @@
 
       // search UI events
       document.getElementById('searchType').addEventListener('change', onSearchTypeChange);
-      document.getElementById('btnSearch').addEventListener('click', ()=>searchPatients());
-      document.getElementById('btnListAll').addEventListener('click', ()=>listPatients());
+      // toolbar buttons wired above; avoid duplicate listeners
       // Enter-to-search
       document.getElementById('searchText').addEventListener('keydown', (e)=>{ if(e.key==='Enter') searchPatients(); });
       document.getElementById('searchDate').addEventListener('keydown', (e)=>{ if(e.key==='Enter') searchPatients(); });


### PR DESCRIPTION
## Summary
- avoid double-triggering search and list-all by removing duplicate event listeners

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68968c5089148323a2687059282abd19