### PR TITLE
Add alert role to error container for screen reader support

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,7 +130,7 @@
     </div>
 
     <div class="sheet-content">
-      <div id="errorContainer" class="error"></div>
+      <div id="errorContainer" class="error" role="alert"></div>
 
       <input type="hidden" id="patientId"/>
 


### PR DESCRIPTION
## Summary
- ensure error messages announced by screen readers by adding role="alert" to error container

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689693a9146883238c0206238dcf53b1