### PR TITLE
Make patient rows keyboard accessible

### DIFF
--- a/index.html
+++ b/index.html
@@ -454,6 +454,7 @@
         const name = humanNameToDisplay(nameObj) || '(no name)';
         const row=document.createElement('tr');
         row.dataset.pid=p.id||'';
+        row.setAttribute('tabindex','0');
         row.innerHTML=`
           <td>${p.id||''}</td>
           <td>${name}</td>
@@ -466,6 +467,16 @@
 
         // Row click -> view sheet
         row.addEventListener('click', async ()=>{ selectRow(row); await viewPatient(p.id); });
+
+        // Keyboard access -> view sheet
+        row.addEventListener('keydown', async (e)=>{
+          if(e.target!==row) return;
+          if(e.key==='Enter' || e.key===' '){
+            e.preventDefault();
+            selectRow(row);
+            await viewPatient(p.id);
+          }
+        });
 
         // Row actions
         const editBtn=row.querySelector('button.edit-btn');


### PR DESCRIPTION
## Summary
- Allow keyboard users to focus each patient row by assigning `tabindex="0"`
- Trigger patient view when pressing Enter or Space on a focused row

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689693a2961c8323b160f4746ac734f7